### PR TITLE
Remove the need for alsa bridge for airplay

### DIFF
--- a/plugins/airplay/Dockerfile.template
+++ b/plugins/airplay/Dockerfile.template
@@ -6,11 +6,8 @@ ENV DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket
 # DL4006: https://github.com/hadolint/hadolint/wiki/DL4006
 SHELL ["/bin/sh", "-eo", "pipefail", "-c"]
 
-# shairport-sync docker image doesn't include pulseaudio support so we use ALSA bridge
-ENV PULSE_SERVER=tcp:localhost:4317
-RUN apk update && apk add --no-cache supervisor curl~=7 && \
-  curl -skL https://raw.githubusercontent.com/balena-io-experimental/audio/master/scripts/alsa-bridge/alpine-setup.sh | sh \
-  && apk del curl
+ENV PULSE_SERVER=tcp:audio:4317
+RUN apk update && apk add --no-cache supervisor
 
 COPY start.sh /usr/src/
 COPY supervisor.conf /usr/src/supervisor.conf


### PR DESCRIPTION
PULSE_SERVER is now officially supported in Shairport Sync Docker image, using the also bridge does not seem useful anymore 

https://github.com/mikebrady/shairport-sync/blob/910264e565095115c4889cc0c5428b3165d15e3f/docker/docker-compose.yaml#L10